### PR TITLE
cleanup duplicate code

### DIFF
--- a/source/Application/Model/Payment.php
+++ b/source/Application/Model/Payment.php
@@ -304,24 +304,19 @@ class Payment extends \oxI18n
         //getting basket price with applied discounts and vouchers
         $dPrice = $this->getPaymentValue($this->getBaseBasketPriceForPaymentCostCalc($oBasket));
 
-        if ($dPrice) {
-            // calculating total price
-            $oPrice = oxNew('oxPrice');
-            $oPrice->setNettoMode($this->_blPaymentVatOnTop);
+        if (!$dPrice) {
+            $dPrice = 0;
+        }
+        // calculating total price
+        $oPrice = oxNew('oxPrice');
+        $oPrice->setNettoMode($this->_blPaymentVatOnTop);
 
-            $oPrice->setPrice($dPrice);
-            if ($dPrice > 0) {
-                $oPrice->setVat($oBasket->getAdditionalServicesVatPercent());
-            }
-
-            $this->_oPrice = $oPrice;
-        } else {
-            // no payment costs
-            $oPrice = oxNew('oxPrice');
-            $oPrice->setPrice(0);
-            $this->_oPrice = $oPrice;
+        $oPrice->setPrice($dPrice);
+        if ($dPrice > 0) {
+            $oPrice->setVat($oBasket->getAdditionalServicesVatPercent());
         }
 
+        $this->_oPrice = $oPrice;
     }
 
     /**


### PR DESCRIPTION
removed if/else condition introduced in bugfix for "0006398: Payment type charges are not deleted changed back to a type with no costs"
because it does nearly the same as the if branch above.